### PR TITLE
Serve track

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
 # Lute
 
 Lute is a self-hosted streaming platform with a focus on listening or watching
-with a group of users.
+with a group of users. Lute is written in [Go](https://go.dev/) and
+[Typescript](https://www.typescriptlang.org/) with a
+[Sveltekit](https://svelte.dev/) frontend.
+
+## Quickstart
+
+You can start Lute via `docker compose`:
+
+```sh
+docker compose up
+```
+

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,1 @@
+lute-config.yaml

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"lute/internal/stream"
 	"net/http"
 	"os"
 
@@ -18,7 +19,6 @@ type ServerConfig struct {
 
 func hello(w http.ResponseWriter, req *http.Request) {
     log.Printf("Received request from: %v", req.RemoteAddr)
-    fmt.Fprintf(w, "hello\n")
 }
 
 func main() {
@@ -40,6 +40,7 @@ func main() {
     }
     
     http.HandleFunc("/hello", hello)
+    http.HandleFunc("/ws", stream.WebsocketHandler)
 
     log.Printf("Starting server...")
     server := &http.Server{

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -41,6 +41,7 @@ func main() {
     
     http.HandleFunc("/hello", hello)
     http.HandleFunc("/ws", stream.WebsocketHandler)
+    http.HandleFunc("/stream", stream.AudioStream)
 
     log.Printf("Starting server...")
     server := &http.Server{

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -2,4 +2,7 @@ module lute
 
 go 1.25.5
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require (
+	github.com/gorilla/websocket v1.5.3 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,3 +1,5 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/backend/internal/stream/stream.go
+++ b/backend/internal/stream/stream.go
@@ -1,0 +1,41 @@
+package stream
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+)
+
+var upgrader = websocket.Upgrader {
+    ReadBufferSize: 1024,
+    WriteBufferSize: 1204,
+    CheckOrigin: checkOrigin,
+}
+
+func checkOrigin(r *http.Request) bool {
+    return true;
+}
+
+func WebsocketHandler(w http.ResponseWriter, r *http.Request) {
+    conn, err := upgrader.Upgrade(w, r, nil)
+    if err != nil {
+        log.Printf("Failed to open websocket connection: %v", err)
+        return
+    }
+    defer conn.Close()
+
+    for {
+        messageType, message, err := conn.ReadMessage()
+        if err != nil {
+            log.Printf("Failed to read incoming websocket message: %v", err)
+            break
+        }
+        log.Printf("Received: %s", message)
+        conn.WriteMessage(messageType, message)
+        if err != nil {
+            log.Printf("Failed to write a message to websocket: %v", err)
+            break
+        }
+    }
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
     image: lute-frontend:latest
     build: frontend/
     ports:
-      - "5173:5173"
+      - "3000:3000"
     depends_on:
       - backend
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
     image: lute-frontend:latest
     build: frontend/
     ports:
-      - "5173:5137"
+      - "5173:5173"
     depends_on:
       - backend
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,12 +6,9 @@ COPY ./ .
 RUN yarn install && \
     yarn build
 
-FROM busybox:1.37.0 AS serve
+FROM node:24-alpine AS serve
 
 WORKDIR /app
-
 COPY --from=build /app/build .
 
-EXPOSE 5173
-ENTRYPOINT ["busybox", "httpd", "-f", "-v", "-p", "5173"]
-
+ENTRYPOINT ["node", "index.js"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,5 +22,8 @@
 		"tailwindcss": "^4.1.17",
 		"typescript": "^5.9.3",
 		"vite": "^7.2.6"
+	},
+	"dependencies": {
+		"@lucide/svelte": "^0.561.0"
 	}
 }

--- a/frontend/src/lib/stream.ts
+++ b/frontend/src/lib/stream.ts
@@ -2,6 +2,12 @@ import { browser } from '$app/environment';
 
 let audioContext: AudioContext;
 
+export interface StreamChunk {
+    ChunkSize: number;
+    Sequence: number;
+    Data: string;
+}
+
 export function getAudioContext() {
     if (!browser) return null;
 
@@ -11,3 +17,21 @@ export function getAudioContext() {
     return audioContext;
 }
 
+export class StreamBuffer {
+    head: number;
+    chunks: Array<StreamChunk>;
+    
+    constructor() {
+        this.head = 0
+        this.chunks = new Array(0);
+    }
+
+    push(data: StreamChunk) {
+        this.chunks.push(data);
+        this.chunks.sort((a, b) => a.Sequence - b.Sequence);
+    }
+
+    pop() {
+        return this.chunks.shift()
+    }
+}

--- a/frontend/src/lib/stream.ts
+++ b/frontend/src/lib/stream.ts
@@ -31,7 +31,7 @@ export class StreamBuffer {
         this.chunks.sort((a, b) => a.Sequence - b.Sequence);
     }
 
-    pop() {
+    next() {
         return this.chunks.shift()
     }
 }

--- a/frontend/src/lib/stream.ts
+++ b/frontend/src/lib/stream.ts
@@ -1,0 +1,13 @@
+import { browser } from '$app/environment';
+
+let audioContext: AudioContext;
+
+export function getAudioContext() {
+    if (!browser) return null;
+
+    if (!audioContext) {
+        audioContext = new AudioContext();
+    }
+    return audioContext;
+}
+

--- a/frontend/src/lib/stream.ts
+++ b/frontend/src/lib/stream.ts
@@ -1,6 +1,6 @@
 import { browser } from '$app/environment';
 
-let audioContext: AudioContext;
+export let audioContext: AudioContext;
 
 export interface StreamChunk {
     ChunkSize: number;
@@ -14,7 +14,6 @@ export function getAudioContext() {
     if (!audioContext) {
         audioContext = new AudioContext();
     }
-    return audioContext;
 }
 
 export class StreamBuffer {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -2,6 +2,7 @@
     import { onMount } from 'svelte';
     import { getAudioContext, audioContext } from '$lib/stream';
     import { type StreamChunk, StreamBuffer } from '$lib/stream';
+    import { Play } from '@lucide/svelte';
 
     let ws: WebSocket;
     let status: string = 'Disconnected';
@@ -67,11 +68,11 @@
         <p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
         <p>Websocket status: {status}</p>
 
-            <div class="p-4 flex flex-col max-w-48 gap-4">
+            <div class="p-5 flex flex-col max-w-48 gap-4 items-center">
                 <button
                     onclick={sendMessage}
                     aria-label="send-message"
-                    class="p-2 text-xl border rounded-full hover:bg-blue-100 active:scale-[0.95] transition shadow-xl cursor-pointer"
+                    class="p-2 text-xl border rounded-full hover:bg-blue-100 active:scale-[0.95] transition shadow cursor-pointer"
                 >
                     Send message to websocket
                 </button>
@@ -79,9 +80,9 @@
                 <button
                     aria-label="play"
                     onclick={play}
-                    class="p-2 text-xl border rounded-full hover:bg-blue-100 active:scale-[0.95] transition shadow-xl cursor-pointer"
+                    class="p-2 max-w-10 max-h-10 text-xl rounded-full bg-lime-400 hover:bg-lime-600 active:scale-[0.95] transition shadow cursor-pointer items-center"
                 >
-                    PLAY
+                    <Play class="h-5 w-5" />
                 </button>
             </div>
     </div>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
     import { onMount } from 'svelte';
+    import { getAudioContext } from '$lib/stream';
 
     let ws: WebSocket;
     let status: string = 'Disconnected';
 
     onMount(() => {
+        audioContext = getAudioContext()
         ws = new WebSocket('ws://localhost:7001/ws');
 
         ws.onopen = () => {
@@ -12,7 +14,8 @@
         };
 
         ws.onmessage = (e) => {
-            status = `Message received: ${e.data}`;
+            const message: string = e.data;
+            status = `Message received: ${message}`;
         };
 
         ws.onclose = (e) => {
@@ -38,5 +41,5 @@
     aria-label="doit"
     class="p-2 text-xl border rounded-full"
 >
-    DO IT
+    TEST
 </button>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,2 +1,42 @@
+<script lang="ts">
+    import { onMount } from 'svelte';
+
+    let ws: WebSocket;
+    let status: string = 'Disconnected';
+
+    onMount(() => {
+        ws = new WebSocket('ws://localhost:7001/ws');
+
+        ws.onopen = () => {
+            status = 'Connected';
+        };
+
+        ws.onmessage = (e) => {
+            status = `Message received: ${e.data}`;
+        };
+
+        ws.onclose = (e) => {
+            status = `Disconnected: ${e}`;
+        };
+
+        ws.onerror = (e) => {
+            status = `Error: ${e}`;
+        };
+
+    });
+
+    const sendMessage = () => {
+       ws.send("Test"); 
+    };
+</script>
+
 <h1>Welcome to SvelteKit</h1>
 <p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+<p>Websocket status: {status}</p>
+<button
+    onclick={sendMessage}
+    aria-label="doit"
+    class="p-2 text-xl border rounded-full"
+>
+    DO IT
+</button>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -188,6 +188,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@lucide/svelte@^0.561.0":
+  version "0.561.0"
+  resolved "https://registry.yarnpkg.com/@lucide/svelte/-/svelte-0.561.0.tgz#ca5f8ce6ed843da99ec47eebdc9e5b1681ff8862"
+  integrity sha512-vofKV2UFVrKE6I4ewKJ3dfCXSV6iP6nWVmiM83MLjsU91EeJcEg7LoWUABLp/aOTxj1HQNbJD1f3g3L0JQgH9A==
+
 "@napi-rs/wasm-runtime@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.0.tgz#c0180393d7862cff0d412e3e1a7c3bd5ea6d9b2f"


### PR DESCRIPTION
A demo for streaming an audio file with the websockets protocol. Also uses some tailwind and lucide to get it in the project.

- Implements an `AudioStream` handler that opens a websocket connection and streams a file to the client.
- The frontend has a very basic sequenced buffer to make sure the file is correctly oriented for decoding and playback.
- Demonstrates how to work with audio context when we live in SSR land.

Currently the demo here just collects the whole file and plays it back. Next up should be streaming in a more immediate fashion and seeking within the buffered audio.